### PR TITLE
refactor: replace when.js with vanilla promises

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,433 @@
 {
   "name": "pinky-swear",
   "version": "1.0.4",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.4",
+      "dependencies": {
+        "debug": "^4.0.0"
+      },
+      "devDependencies": {
+        "chai": "3.5.0",
+        "mocha": "2.5.3",
+        "pre-commit": "1.1.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "1.0.2",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/chai/node_modules/assertion-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chai/node_modules/deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "0.1.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chai/node_modules/deep-eql/node_modules/type-detect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+      "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chai/node_modules/type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "dev": true,
+      "dependencies": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 0.8.x"
+      }
+    },
+    "node_modules/mocha/node_modules/commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.x"
+      }
+    },
+    "node_modules/mocha/node_modules/debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "dev": true,
+      "dependencies": {
+        "ms": "0.7.1"
+      }
+    },
+    "node_modules/mocha/node_modules/debug/node_modules/ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/mocha/node_modules/escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "dev": true,
+      "dependencies": {
+        "inherits": "2.0.3",
+        "minimatch": "0.3.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha/node_modules/glob/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "2.7.3",
+        "sigmund": "1.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha/node_modules/glob/node_modules/minimatch/node_modules/lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/glob/node_modules/minimatch/node_modules/sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "dependencies": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "bin": {
+        "jade": "bin/jade"
+      }
+    },
+    "node_modules/mocha/node_modules/jade/node_modules/commander": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+      "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.x"
+      }
+    },
+    "node_modules/mocha/node_modules/jade/node_modules/mkdirp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+      "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha/node_modules/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mocha/node_modules/mkdirp/node_modules/minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+      "dev": true,
+      "bin": {
+        "supports-color": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mocha/node_modules/to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+      "dev": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+    },
+    "node_modules/pre-commit": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.1.3.tgz",
+      "integrity": "sha1-bV7ZB0BHIHKVjHEaFfZ2qiwjE3c=",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "2.0.1",
+        "which": "1.2.11"
+      }
+    },
+    "node_modules/pre-commit/node_modules/cross-spawn": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.0.1.tgz",
+      "integrity": "sha1-q2/Yk6CZdZ2bhSIOOmQ5felGsPY=",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn-async": "2.2.4",
+        "spawn-sync": "1.0.13"
+      }
+    },
+    "node_modules/pre-commit/node_modules/cross-spawn/node_modules/cross-spawn-async": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.4.tgz",
+      "integrity": "sha1-yajY6aBlAsekYpbjOhoFS10vGBI=",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "4.0.1",
+        "which": "1.2.11"
+      }
+    },
+    "node_modules/pre-commit/node_modules/cross-spawn/node_modules/cross-spawn-async/node_modules/lru-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+      "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
+      "dev": true,
+      "dependencies": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.0.0"
+      }
+    },
+    "node_modules/pre-commit/node_modules/cross-spawn/node_modules/cross-spawn-async/node_modules/lru-cache/node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "node_modules/pre-commit/node_modules/cross-spawn/node_modules/cross-spawn-async/node_modules/lru-cache/node_modules/yallist": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
+      "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ=",
+      "dev": true
+    },
+    "node_modules/pre-commit/node_modules/cross-spawn/node_modules/spawn-sync": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.13.tgz",
+      "integrity": "sha1-kECRua1IoPOvsOhHUhVMAegv2Ng=",
+      "dev": true,
+      "dependencies": {
+        "concat-stream": "1.5.2",
+        "os-shim": "0.1.3"
+      }
+    },
+    "node_modules/pre-commit/node_modules/cross-spawn/node_modules/spawn-sync/node_modules/concat-stream": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+      "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.0.6",
+        "typedarray": "0.0.6"
+      }
+    },
+    "node_modules/pre-commit/node_modules/cross-spawn/node_modules/spawn-sync/node_modules/concat-stream/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "node_modules/pre-commit/node_modules/cross-spawn/node_modules/spawn-sync/node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "string_decoder": "0.10.31",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "node_modules/pre-commit/node_modules/cross-spawn/node_modules/spawn-sync/node_modules/concat-stream/node_modules/readable-stream/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "node_modules/pre-commit/node_modules/cross-spawn/node_modules/spawn-sync/node_modules/concat-stream/node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/pre-commit/node_modules/cross-spawn/node_modules/spawn-sync/node_modules/concat-stream/node_modules/readable-stream/node_modules/process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "node_modules/pre-commit/node_modules/cross-spawn/node_modules/spawn-sync/node_modules/concat-stream/node_modules/readable-stream/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "node_modules/pre-commit/node_modules/cross-spawn/node_modules/spawn-sync/node_modules/concat-stream/node_modules/readable-stream/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "node_modules/pre-commit/node_modules/cross-spawn/node_modules/spawn-sync/node_modules/os-shim": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/pre-commit/node_modules/which": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
+      "integrity": "sha1-yLLu6muMFln6fB3U/aq+lTPcXos=",
+      "dev": true,
+      "dependencies": {
+        "isexe": "1.1.2"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/pre-commit/node_modules/which/node_modules/isexe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+      "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
+      "dev": true
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    }
+  },
   "dependencies": {
     "chai": {
       "version": "3.5.0",
@@ -380,11 +805,6 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
-    },
-    "when": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
-      "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "debug": "^4.0.0",
-    "when": "^3.7.8"
+    "debug": "^4.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/test/pinky-swear.js
+++ b/test/pinky-swear.js
@@ -1,6 +1,5 @@
 
-var PinkySwear = require('../pinky-swear'),
-    when = require('when');
+var PinkySwear = require('../pinky-swear');
 
 function testPinkySwearClass(PinkySwearClass) {
 
@@ -9,7 +8,7 @@ function testPinkySwearClass(PinkySwearClass) {
         it('should return a promise from emit', function () {
             var swear = new PinkySwearClass();
 
-            expect(swear.emit('foo')).to.satisfy(when.isPromiseLike);
+            expect(swear.emit('foo')).to.respondTo('then');
         });
 
         it ('should resolve with no listeners', function () {
@@ -26,7 +25,7 @@ function testPinkySwearClass(PinkySwearClass) {
             var swear = new PinkySwearClass();
 
             swear.on('foo', function () { return 'bar'; });
-            swear.on('foo', function () { return when.resolve('baz').delay(10); });
+            swear.on('foo', function () { return DelayablePromise.resolve('baz').delay(10); });
 
             return swear.emit('foo')
             .then(function _swearResults(results) {
@@ -59,7 +58,7 @@ function testPinkySwearClass(PinkySwearClass) {
                 var swear = new PinkySwearClass();
 
                 swear.once('foo', function () { return 'bar'; });
-                swear.once('foo', function () { return when.resolve('baz').delay(10); });
+                swear.once('foo', function () { return DelayablePromise.resolve('baz').delay(10); });
 
                 return swear.emit('foo')
                 .then(function _swearResults(results) {
@@ -81,3 +80,17 @@ function testPinkySwearClass(PinkySwearClass) {
 
 testPinkySwearClass(PinkySwear);
 testPinkySwearClass(PinkySwear.Parallel);
+
+class DelayablePromise extends Promise {
+    delay (ms) {
+        return this.then(
+            (result) => new Promise(
+                (resolve) => setTimeout(
+                    () => resolve(result),
+                    ms,
+                ),
+            ),
+        );
+    }
+}
+

--- a/test/support/node.js
+++ b/test/support/node.js
@@ -1,6 +1,5 @@
 
-var chai = require("chai"),
-    when = require("when");
+var chai = require("chai");
 
 global.should = chai.should();
 
@@ -9,5 +8,3 @@ global.AssertionError = chai.AssertionError;
 global.Assertion = chai.Assertion;
 global.assert = chai.assert;
 
-global.fulfilledPromise = when.resolve;
-global.rejectedPromise = when.reject;


### PR DESCRIPTION
BREAKING CHANGE: This module now uses and returns vanilla `Promise`
instances. If you were relying on `when.js` sugar methods, you will need
to adjust.